### PR TITLE
fix sphere example

### DIFF
--- a/maxwell_slice/sphere_scat.py
+++ b/maxwell_slice/sphere_scat.py
@@ -38,7 +38,7 @@ def sphere_scat(nnx = 21, nny = 22, nnz = 23):
 
         data = np.fromfile(f'{tmpdir}/data.bin', dtype='>d')
         field = np.fromfile(f'{tmpdir}/field.bin', dtype='>d')
-        data = data.reshape((7, nnx, nny, nnz))
-        field = field.reshape((6, nnx, nny, nnz))
-        field = field[[0,2,4]] + 1j * field[[1,3,5]]
+        data = data.reshape((7, nnx, nny, nnz), order='F')
+        field = field.reshape((6, nnx, nny, nnz), order='F')
+        field = field[[0, 2, 4]] + 1j * field[[1, 3, 5]]
         return data, field

--- a/scratchspace/SphereScat/controls.dat.jinja2
+++ b/scratchspace/SphereScat/controls.dat.jinja2
@@ -1,17 +1,17 @@
 0       ifin (0 -> output scattered field, 1 -> output total field
-0       iscat (0 -> artificial data for accuracy test, 1 true scattering)
+1       iscat (0 -> artificial data for accuracy test, 1 true scattering)
 -10.0d0  xxx(1)    (point in exterior region)
 2.0d0   xxx(2)
 1.300   xxx(3)    
 1       ifpr_geom (print geometry info to file)
 200     numit (max number of GMRES iterations)
 1.0d-9  eps  (GMRES tolerance)
--2.00   xlow  (output grid corners) 
--2.00   ylow  
+-4.00   xlow  (output grid corners) 
+-4.00   ylow  
 -2.00   zlow  
-10.0d0  xhigh
-10.0d0  yhigh
-10.0d0  zhigh
+8.00  xhigh
+20.00  yhigh
+2.00  zhigh
 {{ nnx }}    nnx    (number of points in each dimension)
 {{ nny }}    nny
 {{ nnz }}    nnz

--- a/scratchspace/test_slice_vis/test_slice_vis.ipynb
+++ b/scratchspace/test_slice_vis/test_slice_vis.ipynb
@@ -18,7 +18,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "nnx=160; nny=160; nnz=20;\n",
+    "nnx=80; nny=80; nnz=20;\n",
     "data, field = ms.sphere_scat(nnx, nny, nnz)\n",
     "print(data.shape)\n",
     "print(field.shape)"
@@ -30,16 +30,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "field.shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "V = np.abs(field[0])\n",
+    "\n",
+    "V = np.abs(field[0,:,:,:])\n",
     "\n",
     "# Show three slices\n",
     "fig, ax = plt.subplots(1, 3, figsize=(15, 10))\n",
@@ -52,6 +44,13 @@
     "# Remove axis ticks and labels\n",
     "for i in range(3): ax[i].axis('off');"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {


### PR DESCRIPTION
@alisonsimons

I think I managed to track down the problem with the sphere example. Actually there were two issues. First I changed to Fortran order when reshaping the array (`order='F'`). And second, I updated the controls.dat jinja file so that the output grid included all 10 spheres.